### PR TITLE
Add HTTP server to Geth

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -1,19 +1,3 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
 package backends
 
 import (


### PR DESCRIPTION
Fixes #4

Revise the `accounts/abi/bind/backends/simulated.go` file to remove the copyright notice and license information.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Pjrich1313/go-ethereum/pull/8?shareId=a99f1ba1-239d-418e-b9ec-48994edc123c).